### PR TITLE
03/28/14 Python mtimes scripts revised to use csv text files

### DIFF
--- a/Python/mtimes/README
+++ b/Python/mtimes/README
@@ -1,35 +1,10 @@
-mtimes_save and mtimes_restore python scripts
+mtimes_save and mtimes_restore python scripts - Updated Mar 28, 2014
 =============================================
-Updated 03/17/2014
 
-Overview
---------
-This project contains the following Python(3.3) scripts:
-mtimes_save.py     = saves files modified timestamps
-mtimes_restore.py  = restores files modified timestamps
-hash_files.py      = lists files SHA1 hash and timestamps values
-
-Purpose
--------
-Presevers the date and time that files were modified allowing directory listings to be meaningfully sorted by the date and time files were last edited.  When a repository of files is cloned, the files in the new repository have the current system date time that they were cloned.  Using the mtimes_save.py script to save the files' mtimes in a python pickle formatted data dictionary file just before they are added and commited to the repository.  This provides the ability for running the mtimes_restore.py script to restore these timestamps after cloning or exporting files from the repository.  
-
-The purpose for these scripts is to preserve the timestamps.  When duplicate files are encountered, only the OLDEST timestamp from the duplicate files is saved - because the oldest is closer to the original file's modification datetime.  When duplicate files are restored, they All get the OLDEST timestamp.  File uniqueness is determined by calculating the SHA1 hash value for its contents.  This "OLDEST" for duplicates may be mis-leading for some duplicate content files that may be intentionally distinct by name or path.  For example, if you want 2 README files with identical content to have different timestamps because they are in 2 separate folders - then you would need to execute the mtimes_save.py script inside the local folder for each README and conversely run the mtimes_restore.py script inside the same local folder to restore the README's unique timestamp.
-
-The scripts can easily be modified to be used as git hook scripts.  However, the scripts require reading each file's content to generate an SHA1 hash.  For large repositories, it is better to run the scripts manually when appropriate (e.g. for tagged versions).
-
-The hash_files.py script simply lists each SHA1, timestamp, and file path for each file.  Duplicate files are identified by a "+" character after the displayed SHA1 value.  This makes it easy to identify duplicate files by piping the script to sort.  The sorted listing will show the sorted SHA1 values, oldest files first.
-
-Comments
---------
-I personally find these scripts usefull when working with large quantities of documents, photos, and CNC code files where the timestamps are convenient for sifting through the files using common file explorer tools.  Version control systems like Subversion and Git, do not preserve file timestamps when files are stored or retrieved from them.  For mutable files, timestamps typically are not as important as the "latest version".  I wrote these scripts to save and restore file timestamps for typically immutable files - whose timestamps are valuable attriubutes over a long file storage lifecycle.
-
-//AJ
-
-======================
 Usage:  mtimes_save.py
 
 * Creates a python style dictionary that maps each file's content SHA1 hash value to that file's modified datetime stamp.
-* Writes the dictionary to a python pickle file named:  .mtimes.pickle.
+* Writes the dictionary to a python text file named:  .mtimes.csv
 * Ignores Directories with the "." prefix (e.g. "\.git" or "\.svn").  Note, it does not ignore Files with the "." prefix (e.g. ".gitignore")
 * If duplicate files are found, the Oldest mtime timestamp is saved.
 
@@ -45,16 +20,16 @@ $ git push
 -------------------------
 Usage:  mtimes_restore.py
 
-* Reads the dictionary pickle file created by mtimes_save.py.
+* Reads the dictionary text csv file created by mtimes_save.py.
 * Ignores directories with the "." prefix (e.g. "\.git")
-* Probably crashes if the .mtimes.pickle file is not found.  sorry - I haven't learned python error handling yet!
+* Probably crashes if the .mtimes.csv file is not found.  sorry - I haven't learned python error handling yet!
 
 1.  cd to the top most folder in the directory tree you want to restore file timestamps to.
 2.  run:   python mtimes_restore.py
 
 Typical Get workflow to restore file timestamps
 $ git clone ....
-  # Note:  This only works if you saved an .mtimes.pickle file in the repository
+  # Note:  This only works if you saved an .mtimes.csv file in the repository
 $ python mtimes_restore.py
 
 -------------------------
@@ -76,6 +51,7 @@ Comments:  The SHA1 hash of file content used for uniquely identifying files is 
 Known Issues:  The Python print() and os.path.getmtime() functions do not like file paths that use international characters like hangul and kanja.
 This issue is bypassed by not printing file names in the mtimes save and restore scripts.  However, the hash_files.py script prints file paths for meaningful output, so it probably will crash if your directory contains hangul or kanja folder or file names.
 
+Regarding Pickle Files VS CSV - I experienced compatibility problems between different Python versions and their ability to read Pickle files.  It is possible the compatibility problems were not the Pickle file, but rather the Dictionary object stored in it.  Since the purpose is to preserve the file time stamps (mtimes), the scripts have been revised to use CSV files and data structure that are not dependent on Python versions.
+
 -----------------
 License = n/a:  Submitted to the public domain: 03/15/14  //AJ
-Updated Mar 17, 2014

--- a/Python/mtimes/mtimes_restore.py
+++ b/Python/mtimes/mtimes_restore.py
@@ -15,7 +15,6 @@ import tempfile
 import io
 import hashlib
 import datetime
-import pickle
  
 def system(*args, **kwargs):
     kwargs.setdefault('stdout', subprocess.PIPE)

--- a/Python/mtimes/mtimes_restore.py
+++ b/Python/mtimes/mtimes_restore.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 ## Restore file mtimes
+## 03/28/14 - Save as text CSV file. Compatibility problems with Dictionary in Pickle file between Python Versions
 ## 03/15/14 - Contributed to UAS RandomScripts
 ## 03/08/14 - Python bug in os.path.getmtime(path).  Must use os.stat(path).st_mtime_ns
 ## 03/03/14 - Restore the mtime Time Stamp for each file from the repository.
@@ -23,44 +24,50 @@ def system(*args, **kwargs):
     return out
  
 def save_dictfile(dictobj, fname ):
-  # Pickle the dictionary object to a binary file
-  with open(fname, 'wb') as ff:
-    pickle.dump(dictobj, ff, pickle.HIGHEST_PROTOCOL)
-
+    # Save the dictionary object to a text file
+    with open(fname, 'w') as ff:
+        for kv in dictobj.items():
+            ff.write("%s,%s\n" % kv)
+    
 def load_dictfile(fname):
-  # Retrieve the dictionary pickle from its binary file
-  with open(fname, 'rb') as ff:
-    return pickle.load(ff)
+    # Retrieve the dictionary from its text file
+    di = dict()
+    with open(fname, 'r') as ff:
+        for li in ff:
+            li = li.rstrip ('\n')
+            kv = li.split (',')
+            di[kv[0]] = int(kv[1])
+    return di
 
 def pop_mtimes():
-  mtime_datafile = '.mtimes.pickle'
-  hashdic = dict()
-  hashdic = load_dictfile(mtime_datafile)
-  print(len(hashdic), 'mtime stamps retrieved')
-  ii = 0;
-  for dirpath, dirnames, files in os.walk('.'):
-    # Recurse through the directory tree and ignore \. prefixed folders
-    rgx = re.compile(r'\\\.')
-    if not rgx.search(dirpath):
-      for fname in files:
-        fpath = os.path.join(dirpath, fname);
-        hashky = hashlib.sha1(io.open(fpath, "rb", buffering=0).readall()).hexdigest()
-        # Lookup the Hash Key
-        if hashky in hashdic:
-          if os.stat(fpath).st_mtime_ns != hashdic[hashky]:
-            ii = ii+1
-            # verbose output
-            print('*', hashlib.sha1(io.open(fpath, "rb", buffering=0).readall()).hexdigest(),
-                  '*', os.stat(fpath).st_mtime_ns, '*', hashdic[hashky])
-            oldtime = datetime.datetime.fromtimestamp(os.stat(fpath).st_mtime);
-            os.utime(fpath, ns=(os.stat(fpath).st_mtime_ns, hashdic[hashky]))
-            newtime = datetime.datetime.fromtimestamp(os.stat(fpath).st_mtime);
-            print('**', oldtime, '**', newtime)
-  print(ii, 'file timestamps restored')  
+    mtime_datafile = '.mtimes.csv'
+    hashdic = dict()
+    hashdic = load_dictfile(mtime_datafile)
+    print(len(hashdic), 'mtime stamps retrieved')
+    ii = 0;
+    for dirpath, dirnames, files in os.walk('.'):
+        # Recurse through the directory tree and ignore \. prefixed folders
+        rgx = re.compile(r'\\\.')
+        if not rgx.search(dirpath):
+            for fname in files:
+                fpath = os.path.join(dirpath, fname);
+                hashky = hashlib.sha1(io.open(fpath, "rb", buffering=0).readall()).hexdigest()
+                # Lookup the Hash Key
+                if hashky in hashdic:
+                    if os.stat(fpath).st_mtime_ns != hashdic[hashky]:
+                        ii = ii+1
+                        # verbose output
+                        print('*', hashlib.sha1(io.open(fpath, "rb", buffering=0).readall()).hexdigest(),
+                            '*', os.stat(fpath).st_mtime_ns, '*', hashdic[hashky])
+                        oldtime = datetime.datetime.fromtimestamp(os.stat(fpath).st_mtime);
+                        os.utime(fpath, ns=(os.stat(fpath).st_mtime_ns, hashdic[hashky]))
+                        newtime = datetime.datetime.fromtimestamp(os.stat(fpath).st_mtime);
+                        print('**', oldtime, '**', newtime)
+    print(ii, 'file timestamps restored')  
 
 def main():
-  pop_mtimes()
-  sys.exit(0)
+    pop_mtimes()
+    sys.exit(0)
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/Python/mtimes/mtimes_save.py
+++ b/Python/mtimes/mtimes_save.py
@@ -15,7 +15,6 @@ import tempfile
 import io
 import hashlib
 import datetime
-import pickle
  
 def system(*args, **kwargs):
     kwargs.setdefault('stdout', subprocess.PIPE)
@@ -52,18 +51,11 @@ def push_mtimes():
                 # Check for uniqueness to prevent duplicates
                 if not hashky in hashdic:
                     hashdic[hashky] = os.stat(fpath).st_mtime_ns
-                    #print(len(hashdic), '*', hashky, '+', hashdic[hashky])
-                    ##verbose output
-                    ##print(len(hashdic), '*', hashlib.sha1(io.open(fpath, "rb", buffering=0).readall()).hexdigest(),
-                    ##      '*', os.stat(fpath).st_mtime_ns,
-                    ##      '*', fpath,
-                    ##      '*', datetime.datetime.fromtimestamp(os.stat(fpath).st_mtime_ns))
                 elif os.stat(fpath).st_mtime_ns <  hashdic[hashky]:
                     hashdic[hashky] = os.stat(fpath).st_mtime_ns
-                    #print(len(hashdic), '*', hashky, '..', hashdic[hashky])
 
     save_dictfile(hashdic, mtime_datafile)
-    #For use as a Git pre-commit hook, we have to add our .mtimes.pickle file at the last second before commit
+    #For use as a Git pre-commit hook, we have to add our .mtimes.csv file at the last second before commit
     #*GIT*#print(system('git', 'add', '-v', mtime_datafile))
     print(len(hashdic), 'mtime stamps saved')
 

--- a/Python/mtimes/mtimes_save.py
+++ b/Python/mtimes/mtimes_save.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 ## Save file mtimes
+## 03/28/14 - Save as text CSV file. Compatibility problems with Dictionary in Pickle file between Python Versions
 ## 03/15/14 - Contributed to UAS RandomScripts
 ## 03/06/14 - for pre-commit hook script, uncomment the #*GIT*# line
 ## 03/03/14 - Save Oldest mtime Time Stamp for each file in the repository so it can be restored by post-update
@@ -23,46 +24,52 @@ def system(*args, **kwargs):
     return out
  
 def save_dictfile(dictobj, fname ):
-  # Pickle the dictionary object to a binary file
-  with open(fname, 'wb') as ff:
-    pickle.dump(dictobj, ff, pickle.HIGHEST_PROTOCOL)
-
+    # Save the dictionary object to a text file
+    with open(fname, 'w') as ff:
+        for kv in dictobj.items():
+            ff.write("%s,%s\n" % kv)
+    
 def load_dictfile(fname):
-  # Retrieve the dictionary pickle from its binary file
-  with open(fname, 'rb') as ff:
-    return pickle.load(ff)
+    # Retrieve the dictionary from its text file
+    di = dict()
+    with open(fname, 'r') as ff:
+        for li in ff:
+            li = li.rstrip ('\n')
+            kv = li.split (',')
+            di[kv[0]] = int(kv[1])
+    return di
 
 def push_mtimes():
-  mtime_datafile = '.mtimes.pickle'
-  hashdic = dict()
-  for dirpath, dirnames, files in os.walk('.'):
-    # Recurse through the directory tree and ignore \. prefixed folders
-    rgx = re.compile(r'\\\.')
-    if not rgx.search(dirpath):
-      for fname in files:
-        fpath = os.path.join(dirpath, fname);
-        hashky = hashlib.sha1(io.open(fpath, "rb", buffering=0).readall()).hexdigest()
-        # Check for uniqueness to prevent duplicates
-        if not hashky in hashdic:
-          hashdic[hashky] = os.stat(fpath).st_mtime_ns
-          #print(len(hashdic), '*', hashky, '+', hashdic[hashky])
-          ##verbose output
-          ##print(len(hashdic), '*', hashlib.sha1(io.open(fpath, "rb", buffering=0).readall()).hexdigest(),
-          ##      '*', os.stat(fpath).st_mtime_ns,
-          ##      '*', fpath,
-          ##      '*', datetime.datetime.fromtimestamp(os.stat(fpath).st_mtime_ns))
-        elif os.stat(fpath).st_mtime_ns <  hashdic[hashky]:
-          hashdic[hashky] = os.stat(fpath).st_mtime_ns
-          #print(len(hashdic), '*', hashky, '..', hashdic[hashky])
+    mtime_datafile = '.mtimes.csv'
+    hashdic = dict()
+    for dirpath, dirnames, files in os.walk('.'):
+        # Recurse through the directory tree and ignore \. prefixed folders
+        rgx = re.compile(r'\\\.')
+        if not rgx.search(dirpath):
+            for fname in files:
+                fpath = os.path.join(dirpath, fname);
+                hashky = hashlib.sha1(io.open(fpath, "rb", buffering=0).readall()).hexdigest()
+                # Check for uniqueness to prevent duplicates
+                if not hashky in hashdic:
+                    hashdic[hashky] = os.stat(fpath).st_mtime_ns
+                    #print(len(hashdic), '*', hashky, '+', hashdic[hashky])
+                    ##verbose output
+                    ##print(len(hashdic), '*', hashlib.sha1(io.open(fpath, "rb", buffering=0).readall()).hexdigest(),
+                    ##      '*', os.stat(fpath).st_mtime_ns,
+                    ##      '*', fpath,
+                    ##      '*', datetime.datetime.fromtimestamp(os.stat(fpath).st_mtime_ns))
+                elif os.stat(fpath).st_mtime_ns <  hashdic[hashky]:
+                    hashdic[hashky] = os.stat(fpath).st_mtime_ns
+                    #print(len(hashdic), '*', hashky, '..', hashdic[hashky])
 
-  save_dictfile(hashdic, mtime_datafile)
-  #For use as a Git pre-commit hook, we have to add our .mtimes.pickle file at the last second before commit
-  #*GIT*#print(system('git', 'add', '-v', mtime_datafile))
-  print(len(hashdic), 'mtime stamps saved')
+    save_dictfile(hashdic, mtime_datafile)
+    #For use as a Git pre-commit hook, we have to add our .mtimes.pickle file at the last second before commit
+    #*GIT*#print(system('git', 'add', '-v', mtime_datafile))
+    print(len(hashdic), 'mtime stamps saved')
 
 def main():
-  push_mtimes()
-  sys.exit(0)
+    push_mtimes()
+    sys.exit(0)
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ URL Resolver - resolves short links and tells you the redirect path, can change 
 ###### FreeBSD Scripts ######
 * FreeBSD/beupdate.zsh - Update a FreeBSD system that is using ZFS Boot Environments (ZFS BEs). Dependencies: shells/zsh sysutils/beadm ports-mgmt/portmaster. Optional dependencies: security/sudo
 
-###### Python Scripts ###### contributed Mar 15, 2014, Updated Mar 28, 2014
+###### Python Scripts ###### 
+Contributed Mar 15, 2014, Updated Mar 28, 2014
 * Python/mtimes/ - utility scripts to save and restore file modified timestamps.
   + mtimes_save.py - saves file modified timestamps
   + mtimes_restore.py - restores file modified timestamps

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ URL Resolver - resolves short links and tells you the redirect path, can change 
 ###### FreeBSD Scripts ######
 * FreeBSD/beupdate.zsh - Update a FreeBSD system that is using ZFS Boot Environments (ZFS BEs). Dependencies: shells/zsh sysutils/beadm ports-mgmt/portmaster. Optional dependencies: security/sudo
 
-###### Python Scripts ###### contributed Mar 15, 2014
+###### Python Scripts ###### contributed Mar 15, 2014, Updated Mar 28, 2014
 * Python/mtimes/ - utility scripts to save and restore file modified timestamps.
   + mtimes_save.py - saves file modified timestamps
   + mtimes_restore.py - restores file modified timestamps


### PR DESCRIPTION
Updated Python / mtimes scripts to use csv text instead of pickle file.
